### PR TITLE
Restore module :doc functionality

### DIFF
--- a/src/documentarian.janet
+++ b/src/documentarian.janet
@@ -251,7 +251,7 @@
   aliases)
 
 (defn document-name?
-  `
+  ```
   Given some binding in an environment, determine whether it's eligible for
   rendering as documentation.
 

--- a/src/documentarian.janet
+++ b/src/documentarian.janet
@@ -250,6 +250,19 @@
         (put aliases name ns))))
   aliases)
 
+(defn document-name?
+  `
+  Given some binding in an environment, determine whether it's eligible for
+  rendering as documentation.
+
+  Eligible bindings are:
+  - any bound symbol
+  - `:doc`
+  `
+  [name]
+  (case name
+    :doc true
+    (symbol? name)))
 
 (defn extract-bindings
   ```
@@ -266,7 +279,7 @@
   (each [path env] (pairs envs)
     (def ns (path->ns path defix))
     (each [name meta] (pairs env)
-      (when (and (symbol? name)
+      (when (and (document-name? name)
                  (or (not (get meta :private))
                      include-private?))
         (cond

--- a/src/documentarian.janet
+++ b/src/documentarian.janet
@@ -258,7 +258,7 @@
   Eligible bindings are:
   - any bound symbol
   - `:doc`
-  `
+  ```
   [name]
   (case name
     :doc true


### PR DESCRIPTION
I broke the `(dyn :doc)` feature when I updated `extract-bindings` to
work with the most recent Janet release. We shouldn't simply check if
a binding name is a symbol in order to tell whether it should be
documented; in fact, the set of eligible bindings is all symbols plus a
reserved set of keywords, which is currently `{:doc}`.