### PR TITLE
remove default template leading spaces

### DIFF
--- a/lib/documentarian.janet
+++ b/lib/documentarian.janet
@@ -9,42 +9,42 @@
   The default template for generating the API document
   ```
   ````
-  # {{project-name}} API
+# {{project-name}} API
 
-  {{#project-doc}}
-  {{&project-doc}}
+{{#project-doc}}
+{{&project-doc}}
 
-  {{/project-doc}}
-  {{#modules}}
-  {{#ns}}
-  ## {{ns}}
-  {{/ns}}
+{{/project-doc}}
+{{#modules}}
+{{#ns}}
+## {{ns}}
+{{/ns}}
 
-  {{#items}}{{^first}}, {{/first}}[{{name}}](#{{in-link}}){{/items}}
+{{#items}}{{^first}}, {{/first}}[{{name}}](#{{in-link}}){{/items}}
 
-  {{#doc}}
-  {{&doc}}
+{{#doc}}
+{{&doc}}
 
-  {{/doc}}
-  {{#items}}
-  ## {{name}}
+{{/doc}}
+{{#items}}
+## {{name}}
 
-  **{{kind}}** {{#private?}}| **private**{{/private?}} {{#link}}| [source][{{num}}]{{/link}}
+**{{kind}}** {{#private?}}| **private**{{/private?}} {{#link}}| [source][{{num}}]{{/link}}
 
-  {{#sig}}
-  ```janet
-  {{&sig}}
-  ```
-  {{/sig}}
+{{#sig}}
+```janet
+{{&sig}}
+```
+{{/sig}}
 
-  {{&docstring}}
+{{&docstring}}
 
-  {{#link}}
-  [{{num}}]: {{link}}
-  {{/link}}
+{{#link}}
+[{{num}}]: {{link}}
+{{/link}}
 
-  {{/items}}
-  {{/modules}}
+{{/items}}
+{{/modules}}
   ````)
 
 


### PR DESCRIPTION
Removes 2 leading spaces from the default template.

The spaces were coming through the output, and on github this caused sections following a list to be indented as though it were a multiline list item (I've read this is a markdown thing in general)

For example:
* a janet
* more janets
* multi-




  ^ line
  ^ janets (there are 5 blank new lines preceding this, and just two spaces at the start of the line)


----
```
For example:
* a janet
* more janets
* multi-




  ^ line
  ^ janets  (there are 5 blank new lines preceding this, and just two spaces at the start of the line)
```

Seems odd that multiple zero-space blank lines will still trigger a multiline list item, but I saw people struggling with this back to 2013, and its new to me. But here we are :)